### PR TITLE
[MovieDetail] refact: MVVM 도입

### DIFF
--- a/MoviePedia/Presentation/Cinema/CinemaViewController.swift
+++ b/MoviePedia/Presentation/Cinema/CinemaViewController.swift
@@ -336,13 +336,15 @@ extension CinemaViewController: UICollectionViewDelegate {
             guard let movie = viewModel.movies?[indexPath.row] else { return }
             movieDetailVC.viewModel.input.receivedMovie.send(movie)
             
-            movieDetailVC.likeButtonSelected = { (isLiked) in
-                guard let cell = collectionView.cellForItem(at: indexPath) as? TodayMovieCollectionViewCell else {
+            movieDetailVC.viewModel.output.updateLikedMovie.lazyBind { [weak self] isLiked in
+                guard let self, let isLiked,
+                      let cell = collectionView.cellForItem(at: indexPath) as? TodayMovieCollectionViewCell else {
                     print("Could not find cell")
                     return
                 }
                 cell.likeButton.isSelected = isLiked
             }
+            
             navigationController?.pushViewController(movieDetailVC, animated: true)
         }
     }

--- a/MoviePedia/Presentation/Cinema/CinemaViewController.swift
+++ b/MoviePedia/Presentation/Cinema/CinemaViewController.swift
@@ -332,15 +332,18 @@ extension CinemaViewController {
 extension CinemaViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if indexPath.section == 2 {
-//            let movieDetailVC = MovieDetailViewController(movie: todayMovies[indexPath.item])
-//            movieDetailVC.likeButtonSelected = { (isLiked) in
-//                guard let cell = collectionView.cellForItem(at: indexPath) as? TodayMovieCollectionViewCell else {
-//                    print("Could not find cell")
-//                    return
-//                }
-//                cell.likeButton.isSelected = isLiked
-//            }
-//            navigationController?.pushViewController(movieDetailVC, animated: true)
+            let movieDetailVC = MovieDetailViewController()
+            guard let movie = viewModel.movies?[indexPath.row] else { return }
+            movieDetailVC.viewModel.input.receivedMovie.send(movie)
+            
+            movieDetailVC.likeButtonSelected = { (isLiked) in
+                guard let cell = collectionView.cellForItem(at: indexPath) as? TodayMovieCollectionViewCell else {
+                    print("Could not find cell")
+                    return
+                }
+                cell.likeButton.isSelected = isLiked
+            }
+            navigationController?.pushViewController(movieDetailVC, animated: true)
         }
     }
 }

--- a/MoviePedia/Presentation/MovieDetail/MovieDetailViewController.swift
+++ b/MoviePedia/Presentation/MovieDetail/MovieDetailViewController.swift
@@ -125,7 +125,6 @@ private extension MovieDetailViewController {
             }
         }
         
-//        createSnapshot()
         collectionView.dataSource = dataSource
     }
 }
@@ -159,12 +158,8 @@ private extension MovieDetailViewController {
     
     func movieDeatilInfoSupplemetaryRegistrationHandler(supplementaryView: MovieDetailInfoSupplementaryView, string: String, indexPath: IndexPath) {
         if indexPath.section == 0 {
-            // TODO: - Movie 작업 모델로 분리
-//            let dateStr = movie.release_date ?? "_"
-//            let ratingStr = String(movie.vote_average ?? 0.0)
-//            let genres = (movie.genre_ids?.prefix(2).compactMap{ Genre(rawValue: $0)?.name_kr }) ?? []
-//            let genreStr = genres.joined(separator: ", ")
-//            supplementaryView.configure(with: [dateStr, ratingStr, genreStr])
+            guard let (dateStr, ratingStr, genreStr) = viewModel.output.configureMovieDetailInfo.value else { return }
+            supplementaryView.configure(with: [dateStr, ratingStr, genreStr])
         }
     }
     

--- a/MoviePedia/Presentation/MovieDetail/MovieDetailViewController.swift
+++ b/MoviePedia/Presentation/MovieDetail/MovieDetailViewController.swift
@@ -17,24 +17,11 @@ final class MovieDetailViewController: BaseViewController {
     private var dataSource: DataSource!
     private var snapshot: Snapshot!
     
-    private let networkManager = TMDBNetworkManager.shared
     private var likedMovies: [Movie] { UserDefaultsManager.likedMovies }
     
-    private let movie: Movie
-    private var backdrops: [Image] = []
-    private var posters: [Image] = []
-    private var credits: [Credit] = []
+    let viewModel = MovieDetailViewModel()
     
     var likeButtonSelected: ((Bool) -> Void)?
-    
-    init(movie: Movie) {
-        self.movie = movie
-        super.init(nibName: nil, bundle: nil)
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -43,66 +30,44 @@ final class MovieDetailViewController: BaseViewController {
         configureHierarachy()
         configureConstraints()
         configureCollectionViewDataSource()
-        loadMovieDetail()
+        bind()
     }
     
-    private func loadMovieDetail() {
-        let group = DispatchGroup()
+    private func bind() {
         
-        group.enter()
-        loadMovieImage() {
-            group.leave()
-        }
-
-        group.enter()
-        loadMovieCredit() {
-            group.leave()
+        viewModel.output.configureInitialViewData.lazyBind { [weak self] movie in
+            print("Output configureInitialViewData bind")
+            guard let self, let movie else { return }
+            navigationItem.title = movie.title
         }
         
-        group.notify(queue: .main) {
-            self.createSnapshot()
+        viewModel.output.showErrorAlert.lazyBind { [weak self] errorMessage in
+            print("Output showErrorAlert bind")
+            guard let self, let errorMessage else { return }
+            self.showErrorAlert(message: errorMessage)
         }
-    }
-    
-    private func loadMovieImage(completionHandler: @escaping () -> Void) {
-        let request = ImageRequest(movieID: movie.id)
-        networkManager.request(api: .image(request)) { [self] (image: ImageResponse) in
-            self.backdrops = image.backdrops ?? []
-            self.posters = image.posters ?? []
-            completionHandler()
-        } failureHandler: { error in
-            print(error)
-        }
-    }
-    private func loadMovieCredit(completionHandler: @escaping () -> Void) {
-        let request = CreditRequest(movieID: movie.id)
-        networkManager.request(api: .credit(request)) { [self] (credit: CreditResponse) in
-            self.credits = credit.cast ?? []
-            completionHandler()
-        } failureHandler: { error in
-            self.showErrorAlert(message: error.localizedDescription)
-        }
+        
+        viewModel.input.viewDidLoad.send()
     }
     
     @objc func likedButtonTapped(_ sender: UIButton) {
-        likeButtonSelected?(sender.isSelected)
-        
-        if sender.isSelected {
-            UserDefaultsManager.likedMovies.append(movie)
-        } else if let removeIndex = UserDefaultsManager.likedMovies.firstIndex(where: {$0.id == movie.id }) {
-            UserDefaultsManager.likedMovies.remove(at: removeIndex)
-        }
+//        likeButtonSelected?(sender.isSelected)
+//        
+//        if sender.isSelected {
+//            UserDefaultsManager.likedMovies.append(movie)
+//        } else if let removeIndex = UserDefaultsManager.likedMovies.firstIndex(where: {$0.id == movie.id }) {
+//            UserDefaultsManager.likedMovies.remove(at: removeIndex)
+//        }
     }
 }
 
 //MARK: - Configuration
 private extension MovieDetailViewController {
     func configureViews() {
-        navigationItem.title = movie.title
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: likeButton)
         
-        let isLiked = likedMovies.contains(where: { $0.id == movie.id })
-        likeButton.isSelected = isLiked
+//        let isLiked = likedMovies.contains(where: { $0.id == movie.id })
+//        likeButton.isSelected = isLiked
         likeButton.addTarget(self, action: #selector(likedButtonTapped), for: .touchUpInside)
         
         collectionView.backgroundColor = .moviepedia_background
@@ -238,11 +203,11 @@ private extension MovieDetailViewController {
     func movieDeatilInfoSupplemetaryRegistrationHandler(supplementaryView: MovieDetailInfoSupplementaryView, string: String, indexPath: IndexPath) {
         if indexPath.section == 0 {
             // TODO: - Movie 작업 모델로 분리
-            let dateStr = movie.release_date ?? "_"
-            let ratingStr = String(movie.vote_average ?? 0.0)
-            let genres = (movie.genre_ids?.prefix(2).compactMap{ Genre(rawValue: $0)?.name_kr }) ?? []
-            let genreStr = genres.joined(separator: ", ")
-            supplementaryView.configure(with: [dateStr, ratingStr, genreStr])
+//            let dateStr = movie.release_date ?? "_"
+//            let ratingStr = String(movie.vote_average ?? 0.0)
+//            let genres = (movie.genre_ids?.prefix(2).compactMap{ Genre(rawValue: $0)?.name_kr }) ?? []
+//            let genreStr = genres.joined(separator: ", ")
+//            supplementaryView.configure(with: [dateStr, ratingStr, genreStr])
         }
     }
     
@@ -283,35 +248,37 @@ private extension MovieDetailViewController {
     }
     
     func createSnapshot() {
-        let backdropItems = backdrops.prefix(5).map{ Item(backdrop: $0) }
-        let synopsysItems = [Item(synopsis: movie.overview ?? "")]
-        let creditItems = credits.map{ Item(cast: $0) }
-        let posterItems: [Item] = posters.map{ Item(poster: $0) }
-        
-        snapshot = Snapshot()
-        snapshot.appendSections([.backdrop, .synopsys, .cast, .poster])
-        snapshot.appendItems(backdropItems, toSection: .backdrop)
-        snapshot.appendItems(synopsysItems, toSection: .synopsys)
-        snapshot.appendItems(creditItems, toSection: .cast)
-        snapshot.appendItems(posterItems, toSection: .poster)
-        dataSource.apply(snapshot)
+//        let backdropItems = backdrops.prefix(5).map{ Item(backdrop: $0) }
+//        let synopsysItems = [Item(synopsis: movie.overview ?? "")]
+//        let creditItems = credits.map{ Item(cast: $0) }
+//        let posterItems: [Item] = posters.map{ Item(poster: $0) }
+//        
+//        snapshot = Snapshot()
+//        snapshot.appendSections([.backdrop, .synopsys, .cast, .poster])
+//        snapshot.appendItems(backdropItems, toSection: .backdrop)
+//        snapshot.appendItems(synopsysItems, toSection: .synopsys)
+//        snapshot.appendItems(creditItems, toSection: .cast)
+//        snapshot.appendItems(posterItems, toSection: .poster)
+//        dataSource.apply(snapshot)
     }
+    
+
 }
 
 //MARK: - CollectionView Delegate
 extension MovieDetailViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-        if indexPath.section == 0 {
-            let indexPathForBackdrop = IndexPath(item: 0, section: 0)
-            let supplementaryView = collectionView.supplementaryView(forElementKind: "layout-footer-element-kind", at: indexPathForBackdrop)
-                        
-            guard let movieInfoView = supplementaryView as? MovieDetailInfoSupplementaryView else { return }
-            if movieInfoView.pageControl.numberOfPages != 5
-               || movieInfoView.pageControl.numberOfPages != backdrops.count {
-                movieInfoView.pageControl.numberOfPages = backdrops.count > 5 ? 5 : backdrops.count
-            }
-            movieInfoView.pageControl.currentPage = indexPath.item
-        }
+//        if indexPath.section == 0 {
+//            let indexPathForBackdrop = IndexPath(item: 0, section: 0)
+//            let supplementaryView = collectionView.supplementaryView(forElementKind: "layout-footer-element-kind", at: indexPathForBackdrop)
+//                        
+//            guard let movieInfoView = supplementaryView as? MovieDetailInfoSupplementaryView else { return }
+//            if movieInfoView.pageControl.numberOfPages != 5
+//               || movieInfoView.pageControl.numberOfPages != backdrops.count {
+//                movieInfoView.pageControl.numberOfPages = backdrops.count > 5 ? 5 : backdrops.count
+//            }
+//            movieInfoView.pageControl.currentPage = indexPath.item
+//        }
     }
 }
 

--- a/MoviePedia/Presentation/MovieDetail/MovieDetailViewController.swift
+++ b/MoviePedia/Presentation/MovieDetail/MovieDetailViewController.swift
@@ -17,11 +17,7 @@ final class MovieDetailViewController: BaseViewController {
     private var dataSource: DataSource!
     private var snapshot: Snapshot!
     
-    private var likedMovies: [Movie] { UserDefaultsManager.likedMovies }
-    
     let viewModel = MovieDetailViewModel()
-    
-    var likeButtonSelected: ((Bool) -> Void)?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -53,17 +49,16 @@ final class MovieDetailViewController: BaseViewController {
             self.createSnapshot(movieDetail)
         }
         
+        viewModel.output.setLikedState.lazyBind { [weak self] isLiked in
+            guard let self, let isLiked else { return }
+            likeButton.isSelected = isLiked
+        }
+        
         viewModel.input.viewDidLoad.send()
     }
     
     @objc func likedButtonTapped(_ sender: UIButton) {
-//        likeButtonSelected?(sender.isSelected)
-//        
-//        if sender.isSelected {
-//            UserDefaultsManager.likedMovies.append(movie)
-//        } else if let removeIndex = UserDefaultsManager.likedMovies.firstIndex(where: {$0.id == movie.id }) {
-//            UserDefaultsManager.likedMovies.remove(at: removeIndex)
-//        }
+        viewModel.input.didTapLikedButton.send(sender.isSelected)
     }
 }
 
@@ -72,8 +67,6 @@ private extension MovieDetailViewController {
     func configureViews() {
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: likeButton)
         
-//        let isLiked = likedMovies.contains(where: { $0.id == movie.id })
-//        likeButton.isSelected = isLiked
         likeButton.addTarget(self, action: #selector(likedButtonTapped), for: .touchUpInside)
         
         collectionView.backgroundColor = .moviepedia_background

--- a/MoviePedia/Presentation/MovieDetail/MovieDetailViewController.swift
+++ b/MoviePedia/Presentation/MovieDetail/MovieDetailViewController.swift
@@ -48,6 +48,7 @@ final class MovieDetailViewController: BaseViewController {
         }
         
         viewModel.output.createSnapshot.lazyBind { [weak self] movieDetail in
+            print("Ouytput createSnapshot bind")
             guard let self, let movieDetail else { return }
             self.createSnapshot(movieDetail)
         }
@@ -216,17 +217,19 @@ private extension MovieDetailViewController {
 //MARK: - CollectionView Delegate
 extension MovieDetailViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-//        if indexPath.section == 0 {
-//            let indexPathForBackdrop = IndexPath(item: 0, section: 0)
-//            let supplementaryView = collectionView.supplementaryView(forElementKind: "layout-footer-element-kind", at: indexPathForBackdrop)
-//                        
-//            guard let movieInfoView = supplementaryView as? MovieDetailInfoSupplementaryView else { return }
-//            if movieInfoView.pageControl.numberOfPages != 5
-//               || movieInfoView.pageControl.numberOfPages != backdrops.count {
-//                movieInfoView.pageControl.numberOfPages = backdrops.count > 5 ? 5 : backdrops.count
-//            }
-//            movieInfoView.pageControl.currentPage = indexPath.item
-//        }
+        if indexPath.section == 0 {
+            let indexPathForBackdrop = IndexPath(item: 0, section: 0)
+            let supplementaryView = collectionView.supplementaryView(forElementKind: "layout-footer-element-kind", at: indexPathForBackdrop)
+                        
+            guard let movieInfoView = supplementaryView as? MovieDetailInfoSupplementaryView else { return }
+            let backdropCount = viewModel.backdrops.count
+            
+            if movieInfoView.pageControl.numberOfPages != 5
+               || movieInfoView.pageControl.numberOfPages != backdropCount {
+                movieInfoView.pageControl.numberOfPages = backdropCount > 5 ? 5 : backdropCount
+            }
+            movieInfoView.pageControl.currentPage = indexPath.item
+        }
     }
 }
 

--- a/MoviePedia/Presentation/MovieDetail/MovieDetailViewModel.swift
+++ b/MoviePedia/Presentation/MovieDetail/MovieDetailViewModel.swift
@@ -26,7 +26,7 @@ final class MovieDetailViewModel: BaseViewModel {
     
     // Data
     private let networkManager = TMDBNetworkManager.shared
-    private var backdrops: [Image] = []
+    var backdrops: [Image] = []
     private var posters: [Image] = []
     private var credits: [Credit] = []
     
@@ -46,6 +46,7 @@ final class MovieDetailViewModel: BaseViewModel {
     func transform() {
         
         input.viewDidLoad.lazyBind { [weak self] _ in
+            print("Input viewDidLoad bind")
             guard let self else { return }
             self.shouldLoadMovieDetail()
             self.configureMovieDetailInfo()

--- a/MoviePedia/Presentation/MovieDetail/MovieDetailViewModel.swift
+++ b/MoviePedia/Presentation/MovieDetail/MovieDetailViewModel.swift
@@ -19,8 +19,9 @@ final class MovieDetailViewModel: BaseViewModel {
     
     struct Output {
         let showErrorAlert: Observable<String?> = Observable(nil)
-        let configureInitialViewData: Observable<Movie?> = Observable(nil)
+        let configureInitialViewData: Observable<(Movie)?> = Observable(nil)
         let createSnapshot: Observable<MovieDetail?> = Observable(nil)
+        let configureMovieDetailInfo: Observable<(String, String, String)?> = Observable(nil)
     }
     
     // Data
@@ -46,7 +47,8 @@ final class MovieDetailViewModel: BaseViewModel {
         
         input.viewDidLoad.lazyBind { [weak self] _ in
             guard let self else { return }
-            shouldLoadMovieDetail()
+            self.shouldLoadMovieDetail()
+            self.configureMovieDetailInfo()
         }
     }
 }
@@ -88,7 +90,7 @@ private extension MovieDetailViewModel {
     func shouldLoadMovieDetail() {
         guard let receivedMovie = input.receivedMovie.value else { return }
         self.loadMovieDetail(receivedMovie)
-        output.configureInitialViewData.send(receivedMovie)
+        self.output.configureInitialViewData.send(receivedMovie)
     }
     
     func loadMovieDetail(_ movie: Movie) {
@@ -139,5 +141,15 @@ private extension MovieDetailViewModel {
         let movieDetail = (backdropItems, synopsysItems, creditItems, posterItems)
         
         output.createSnapshot.send(movieDetail)
+    }
+    
+    func configureMovieDetailInfo() {
+        guard let movie = input.receivedMovie.value else { return }
+        
+        let dateStr = movie.release_date ?? "_"
+        let ratingStr = String(movie.vote_average ?? 0.0)
+        let genres = (movie.genre_ids?.prefix(2).compactMap{ Genre(rawValue: $0)?.name_kr }) ?? []
+        let genreStr = genres.joined(separator: ", ")
+        output.configureMovieDetailInfo.send((dateStr, ratingStr, genreStr))
     }
 }

--- a/MoviePedia/Presentation/MovieDetail/MovieDetailViewModel.swift
+++ b/MoviePedia/Presentation/MovieDetail/MovieDetailViewModel.swift
@@ -1,0 +1,99 @@
+//
+//  MovieDetailViewModel.swift
+//  MoviePedia
+//
+//  Created by 임윤휘 on 2/13/25.
+//
+
+import Foundation
+
+final class MovieDetailViewModel: BaseViewModel {
+    
+    private(set) var input: Input
+    private(set) var output: Output
+    
+    struct Input {
+        let receivedMovie: Observable<Movie?> = Observable(nil)
+        let viewDidLoad: Observable<Void> = Observable(())
+    }
+    
+    struct Output {
+        let showErrorAlert: Observable<String?> = Observable(nil)
+        let configureInitialViewData: Observable<Movie?> = Observable(nil)
+        let createSnapshot: Observable<Void> = Observable(())
+    }
+    
+    // Data
+    private let networkManager = TMDBNetworkManager.shared
+    private var backdrops: [Image] = []
+    private var posters: [Image] = []
+    private var credits: [Credit] = []
+    
+    init() {
+        print("MovieDetailViewModel init")
+        
+        input = Input()
+        output = Output()
+        
+        transform()
+    }
+    
+    deinit {
+        print("MovieDetailViewModel deinit")
+    }
+    
+    func transform() {
+        
+        input.viewDidLoad.lazyBind { [weak self] _ in
+            guard let self else { return }
+            shouldLoadMovieDetail()
+        }
+    }
+}
+
+private extension MovieDetailViewModel {
+    
+    func shouldLoadMovieDetail() {
+        guard let receivedMovie = input.receivedMovie.value else { return }
+        self.loadMovieDetail(receivedMovie)
+        output.configureInitialViewData.send(receivedMovie)
+    }
+    
+    func loadMovieDetail(_ movie: Movie) {
+        let group = DispatchGroup()
+        
+        group.enter()
+        loadMovieImage(movie.id) {
+            group.leave()
+        }
+
+        group.enter()
+        loadMovieCredit(movie.id) {
+            group.leave()
+        }
+        
+        group.notify(queue: .main) {
+//            self.createSnapshot()
+        }
+    }
+    
+    func loadMovieImage(_ movieId: Int, completionHandler: @escaping () -> Void) {
+        let request = ImageRequest(movieID: movieId)
+        networkManager.request(api: .image(request)) { [self] (image: ImageResponse) in
+            self.backdrops = image.backdrops ?? []
+            self.posters = image.posters ?? []
+            completionHandler()
+        } failureHandler: { error in
+            print(error)
+        }
+    }
+    func loadMovieCredit(_ movieId: Int, completionHandler: @escaping () -> Void) {
+        let request = CreditRequest(movieID: movieId)
+        networkManager.request(api: .credit(request)) { [self] (credit: CreditResponse) in
+            self.credits = credit.cast ?? []
+            completionHandler()
+        } failureHandler: { error in
+            self.output.showErrorAlert.send(error.localizedDescription)
+        }
+    }
+}

--- a/MoviePedia/Presentation/MovieSearch/MovieSearchViewController.swift
+++ b/MoviePedia/Presentation/MovieSearch/MovieSearchViewController.swift
@@ -181,8 +181,9 @@ extension MovieSearchViewController: UICollectionViewDelegate {
         let movie = viewModel.movies[indexPath.row]
         movieDetailVC.viewModel.input.receivedMovie.send(movie)
         
-        movieDetailVC.likeButtonSelected = { (isLiked) in
-            guard let cell = collectionView.cellForItem(at: indexPath) as? MovieListCollectionViewCell else {
+        movieDetailVC.viewModel.output.updateLikedMovie.lazyBind { [weak self] isLiked in
+            guard let self, let isLiked,
+                  let cell = collectionView.cellForItem(at: indexPath) as? MovieListCollectionViewCell else {
                 print("Could not find cell")
                 return
             }

--- a/MoviePedia/Presentation/MovieSearch/MovieSearchViewController.swift
+++ b/MoviePedia/Presentation/MovieSearch/MovieSearchViewController.swift
@@ -176,16 +176,19 @@ private extension MovieSearchViewController {
 extension MovieSearchViewController: UICollectionViewDelegate {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-//        guard indexPath.section == 1 else { return }
-//        let movieDetailVC = MovieDetailViewController(movie: movies[indexPath.item])
-//        movieDetailVC.likeButtonSelected = { (isLiked) in
-//            guard let cell = collectionView.cellForItem(at: indexPath) as? MovieListCollectionViewCell else {
-//                print("Could not find cell")
-//                return
-//            }
-//            cell.likeButton.isSelected = isLiked
-//        }
-//        navigationController?.pushViewController(movieDetailVC, animated: true)
+        guard indexPath.section == 1 else { return }
+        let movieDetailVC = MovieDetailViewController()
+        let movie = viewModel.movies[indexPath.row]
+        movieDetailVC.viewModel.input.receivedMovie.send(movie)
+        
+        movieDetailVC.likeButtonSelected = { (isLiked) in
+            guard let cell = collectionView.cellForItem(at: indexPath) as? MovieListCollectionViewCell else {
+                print("Could not find cell")
+                return
+            }
+            cell.likeButton.isSelected = isLiked
+        }
+        navigationController?.pushViewController(movieDetailVC, animated: true)
     }
     
     func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {

--- a/MoviePedia/Presentation/MovieSearch/MovieSearchViewModel.swift
+++ b/MoviePedia/Presentation/MovieSearch/MovieSearchViewModel.swift
@@ -33,7 +33,7 @@ final class MovieSearchViewModel: BaseViewModel {
     
     // Data
     private let networkManager = TMDBNetworkManager.shared
-    private var movies: [Movie] = []
+    var movies: [Movie] = []
     private var currentPage: Int = 1
     private var totalPage: Int?
     private var likedMovies: [Movie] { UserDefaultsManager.likedMovies }


### PR DESCRIPTION
## related
#18 

<br>


## 구현
- Cinema 오늘의 영화 목록 snapshot 업데이트 시 아이템 목록 구성 로직 개선(Section과 Item을 ViewModel로 이동)
- MovieDetail MVVM 도입
    - Movie, Backdrop / Poster,  Cast

<br>

## Issue
- UserDefaults의 likesMovies를 딕셔너리로 개선(key - movieID)
- 영화 뷰 - 뷰모델 분리
- 페이지 컨트롤 초기 설정 오류 수정 필요


<br>




## 미리보기
